### PR TITLE
ovirt-minimal-setup

### DIFF
--- a/ovirt-minimal-setup/Vagrantfile
+++ b/ovirt-minimal-setup/Vagrantfile
@@ -11,13 +11,13 @@ def network_options(type, ip, dhcp_enable)
     options
 end
 
-def ipv6_network_options(type, ip, dhcp_enable, ipv6, ipv6_prefix)
+def ipv6_network_options(type, ip, dhcp_enable, ipv6_gateway, ipv6_prefix)
     options = {}
         options[:ip] = ip
         options[:type] = type
         options[:libvirt__dhcp_enabled] = dhcp_enable
         options[:libvirt__guest_ipv6] = "yes"
-        options[:libvirt__ipv6_address] = ipv6
+        options[:libvirt__ipv6_address] = ipv6_gateway
         options[:libvirt__ipv6_prefix] = ipv6_prefix
         options
 end

--- a/ovirt-minimal-setup/Vagrantfile
+++ b/ovirt-minimal-setup/Vagrantfile
@@ -70,23 +70,23 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.define "host0" do |node|
-            node.vm.box = "centos/7"
+        node.vm.box = "centos/7"
 
-            node.vm.provider :libvirt do |domain|
-                domain.memory = 4096
-            end
+        node.vm.provider :libvirt do |domain|
+            domain.memory = 4096
+        end
 
-            if ENV.has_key?("IPV6_ONLY")
-                # For pure IPv6 deployment
-                node.vm.network :private_network,
-                    ipv6_network_options("nat", "192.168.250.100", false, "fd00:1234:5678:500::1", "64")
-                shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::100/64", "fd00:1234:5678:500::1", "eth1"))
-            end
+        if ENV.has_key?("IPV6_ONLY")
+            # For pure IPv6 deployment
+            node.vm.network :private_network,
+                ipv6_network_options("nat", "192.168.250.100", false, "fd00:1234:5678:500::1", "64")
+            shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::100/64", "fd00:1234:5678:500::1", "eth1"))
+        end
 
-            copy_file(node, "../common/scripts/host_nfs_storage_setup.sh", "/tmp/host_nfs_storage_setup.sh")
-            copy_file(node, "../common/scripts/host_setup.sh", "/tmp/host_setup.sh")
+        copy_file(node, "../common/scripts/host_nfs_storage_setup.sh", "/tmp/host_nfs_storage_setup.sh")
+        copy_file(node, "../common/scripts/host_setup.sh", "/tmp/host_setup.sh")
 
-            shell_provision(node, "sh /tmp/host_setup.sh")
+        shell_provision(node, "sh /tmp/host_setup.sh")
     end
 
     config.vm.provision "shell", inline: <<-SHELL

--- a/ovirt-minimal-setup/Vagrantfile
+++ b/ovirt-minimal-setup/Vagrantfile
@@ -56,10 +56,12 @@ Vagrant.configure("2") do |config|
             domain.memory = 4096
         end
 
-        # For pure IPv6 deployment
-        node.vm.network :private_network,
-                   ipv6_network_options("nat", "192.168.250.200", false, "fd00:1234:5678:500::1", "64")
-        shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::200/64", "fd00:1234:5678:500::1", "eth1"))
+        if ENV.has_key?("IPV6_ONLY")
+            # For pure IPv6 deployment
+            node.vm.network :private_network,
+                ipv6_network_options("nat", "192.168.250.200", false, "fd00:1234:5678:500::1", "64")
+            shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::200/64", "fd00:1234:5678:500::1", "eth1"))
+        end
 
         copy_file(node, "../common/scripts/engine_setup.sh", "/tmp/engine_setup.sh")
         copy_file(node, "../common/answers/answer.conf", "/tmp/answer.conf")
@@ -74,10 +76,12 @@ Vagrant.configure("2") do |config|
                 domain.memory = 4096
             end
 
-            # For pure IPv6 deployment
-            node.vm.network :private_network,
-                        ipv6_network_options("nat", "192.168.250.100", false, "fd00:1234:5678:500::1", "64")
-            shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::100/64", "fd00:1234:5678:500::1", "eth1"))
+            if ENV.has_key?("IPV6_ONLY")
+                # For pure IPv6 deployment
+                node.vm.network :private_network,
+                    ipv6_network_options("nat", "192.168.250.100", false, "fd00:1234:5678:500::1", "64")
+                shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::100/64", "fd00:1234:5678:500::1", "eth1"))
+            end
 
             copy_file(node, "../common/scripts/host_nfs_storage_setup.sh", "/tmp/host_nfs_storage_setup.sh")
             copy_file(node, "../common/scripts/host_setup.sh", "/tmp/host_setup.sh")


### PR DESCRIPTION
- Fix wrong formatting and virable naming

- Add env variable to check if the setup should be deployed with IPv6 network