### PR TITLE
ovirt-minimal-setup: Move nfs dtorage to engine

### DIFF
--- a/common/scripts/nfs_storage_setup.sh
+++ b/common/scripts/nfs_storage_setup.sh
@@ -1,4 +1,4 @@
-#/bin/sh -xe
+#!/bin/sh -xe
 
 DATA_FOLDER="/exports/data"
 ISO_FOLDER="/exports/iso"

--- a/ovirt-minimal-setup/Vagrantfile
+++ b/ovirt-minimal-setup/Vagrantfile
@@ -65,6 +65,7 @@ Vagrant.configure("2") do |config|
 
         copy_file(node, "../common/scripts/engine_setup.sh", "/tmp/engine_setup.sh")
         copy_file(node, "../common/answers/answer.conf", "/tmp/answer.conf")
+        copy_file(node, "../common/scripts/host_nfs_storage_setup.sh", "/tmp/host_nfs_storage_setup.sh")
 
         shell_provision(node, "sh /tmp/engine_setup.sh")
     end
@@ -83,7 +84,6 @@ Vagrant.configure("2") do |config|
             shell_provision(node, ipv6_only_host_setup("fd00:1234:5678:500::100/64", "fd00:1234:5678:500::1", "eth1"))
         end
 
-        copy_file(node, "../common/scripts/host_nfs_storage_setup.sh", "/tmp/host_nfs_storage_setup.sh")
         copy_file(node, "../common/scripts/host_setup.sh", "/tmp/host_setup.sh")
 
         shell_provision(node, "sh /tmp/host_setup.sh")


### PR DESCRIPTION
As storage is crucial to the env we need to make sure that
the engine is still capable to operate even if the host is lost.

Signed-off-by: Ales Musil <amusil@redhat.com>